### PR TITLE
fix(giveaway): host member is undefined on giveaway start

### DIFF
--- a/src/Giveaways.ts
+++ b/src/Giveaways.ts
@@ -741,9 +741,17 @@ export class Giveaways<
             isEnded: false
         }
 
+        const hostMember = await this.client.users.fetch(hostMemberID).catch(console.error) as User;
+        if (!hostMember) {
+          throw new GiveawaysError(
+            errorMessages.USER_NOT_FOUND(hostMemberID),
+            GiveawaysErrorCodes.USER_NOT_FOUND
+          );
+        }
+
         const definedEmbedStrings = defineEmbedStrings ? defineEmbedStrings<true>(
-            giveawayTemplate as any,
-            this.client.users.cache.get(hostMemberID) as User
+          giveawayTemplate as any,
+          hostMember
         ) : {}
 
         const startEmbedStrings = definedEmbedStrings?.start || {}


### PR DESCRIPTION
change method to get host member of the giveaway from cache to fetch, in my case the owner of giveaway is not included in cache of discord client users resulting in undefined on defineEmbedStrings